### PR TITLE
chore: Add --only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ npm run aoc
 npm run aoc -- --day=1
 # run in watch mode
 npm run aoc -- --watch
+# run only tests marked as only
+npm run aoc -- --only
 
 # run all validations
 npm run validate

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=21.0.0"
   },
   "scripts": {
-    "aoc": "ts-node --transpile-only \"./test/testRunner.ts\"",
+    "aoc": "node \"./test/testRunner.mjs\"",
     "ts:check": "tsc",
     "lint:check": "eslint . --ext .js,.ts,.cjs,.mjs --ignore-path .gitignore",
     "lint:fix": "npm run lint:check -- --fix",

--- a/src/day-02/test.ts
+++ b/src/day-02/test.ts
@@ -16,8 +16,8 @@ describe('day-02', async () => {
   const reader = new InputReader(__dirname)
   const { inputExample, inputReal } = await reader.readAllInputFiles()
 
-  describe('helpers', () => {
-    it('parseFile()', () => {
+  describe('helpers', { only: true }, () => {
+    it('parseFile()', { only: true }, () => {
       const input = '1 2 3 4 5\n6 7 8 9 8\n\n'
       const result = parseFile(input)
       const expected = [

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,0 +1,1 @@
+export const TEST_ONLY = { only: true } as const

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts", "test/**/*.js", "test/**/*.mjs"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
```bash
npm run aoc -- --only
```

Note that only those test cases will be picked up where they themself **+ all their ancestor describe blocks** have `{only:true}` option set.

![image](https://github.com/user-attachments/assets/daf605cc-0ada-44ae-b93b-f2f76d4358a8)
